### PR TITLE
Fix status message not appearing on node disconnect

### DIFF
--- a/src/redux/providers/status.js
+++ b/src/redux/providers/status.js
@@ -89,11 +89,11 @@ export default class Status {
 
     self._clearTimeouts();
 
+    self.updateApiStatus();
     return self._unsubscribeBlockNumber()
       .catch((error) => {
         console.error('status::stop', error);
-      })
-      .then(() => self.updateApiStatus());
+      });
   }
 
   getApiStatus = () => {


### PR DESCRIPTION
Attempt to fix https://github.com/paritytech/parity/issues/7320.

### Diagnosis

When the node disconnects, this [stop method](https://github.com/paritytech/js-shared/blob/am-fix-status/src/redux/providers/status.js#L81-L97) is called. I added two console.logs to see what happens:
```javascript
  static stop () {
    if (!instance) {
      return Promise.resolve();
    }

    const self = instance;

    log.debug('status::stop');

    self._clearTimeouts();

    console.log('START self._unsubscribeBlockNumber()')
    return self._unsubscribeBlockNumber()
      .catch((error) => {
        console.error('status::stop', error);
      })
      .then(() => {console.log('RESOLVE self._unsubscribeBlockNumber()'); return self.updateApiStatus() });
  }
```

`self.updateApiStatus()` is the redux action that will decide to show the Disconnected Node message. So 'START' is console.logged normally right after the node disconnects, and we would expect to see 'RESOLVE' shortly after, so that `self.updateApiStatus()` can show the message. But the promise never resolves, and only resolves when the node reconnects.

@jacogr It's related to this PR: https://github.com/paritytech/js-api/pull/22/files. If I remove the 3 lines that you added, the behavior is working.

Right now this PR makes everything work (play around before merging), but it's more a patch than a real fix. If you find a better solution, feel free to close this PR.